### PR TITLE
Simplify how events are sent

### DIFF
--- a/bridge.cpp
+++ b/bridge.cpp
@@ -45,7 +45,7 @@ Engine::Engine(fcitx::Instance *instance) : instance_(instance) {
 
   ctx = new zmq::context_t();
   sock = new zmq::socket_t(*ctx, ZMQ_REQ);
-  sock->bind("tcp://127.0.0.1:8085");
+  sock->connect("tcp://127.0.0.1:8085");
 
   fcitx::EventDispatcher *dispatcher = new fcitx::EventDispatcher();
   this->dispatcher = dispatcher;
@@ -90,7 +90,7 @@ void Engine::keyEvent(const fcitx::InputMethodEntry &entry,
 
   zmq::message_t keyMsg(serialized.size());
   memcpy(keyMsg.data(), serialized.data(), serialized.size());
-  sock->send(keyMsg, zmq::send_flags::dontwait);
+  sock->send(keyMsg, zmq::send_flags::none);
 
   zmq::message_t reply;
   zmq::recv_result_t maybeSize = sock->recv(reply);

--- a/bridge.cpp
+++ b/bridge.cpp
@@ -38,20 +38,10 @@ public:
   void select(fcitx::InputContext *) const {};
 };
 
-// If we are out of an input session and the following key happens, we do not
-// pass it to the input method engine.
-static const std::array<fcitx::Key, 10> outOfSessionSkip = {
-    fcitx::Key{FcitxKey_Return}, fcitx::Key{FcitxKey_space},
-    fcitx::Key{FcitxKey_Escape}, fcitx::Key{FcitxKey_Tab},
-    fcitx::Key{FcitxKey_Up},     fcitx::Key{FcitxKey_Down},
-    fcitx::Key{FcitxKey_Left},   fcitx::Key{FcitxKey_Right},
-    fcitx::Key{FcitxKey_Delete}, fcitx::Key{FcitxKey_BackSpace}};
-
 Engine *engine;
 
 Engine::Engine(fcitx::Instance *instance) : instance_(instance) {
   engine = this;
-  isInSession = false;
 
   ctx = new zmq::context_t();
   pub = new zmq::socket_t(*ctx, ZMQ_PUB);
@@ -89,7 +79,7 @@ void Engine::keyEvent(const fcitx::InputMethodEntry &entry,
                       fcitx::KeyEvent &keyEvent) {
   FCITX_UNUSED(entry);
 
-  if (!keep(keyEvent)) {
+  if (keyEvent.isRelease() || keyEvent.key().isModifier()) {
     return;
   }
 
@@ -110,20 +100,6 @@ void Engine::reset(const fcitx::InputMethodEntry &,
   FCITX_UNUSED(event);
 }
 
-void Engine::inSession(const bool isInSession) {
-  this->mtxInSession.lock();
-  this->isInSession = isInSession;
-  this->mtxInSession.unlock();
-}
-
-bool Engine::inSession() {
-  this->mtxInSession.lock_shared();
-  bool toReturn = this->isInSession;
-  this->mtxInSession.unlock_shared();
-
-  return toReturn;
-}
-
 fcitx::InputContext *Engine::getInputContext() { return ic; }
 
 fcitx::Instance *Engine::getInstance() { return instance_; }
@@ -137,23 +113,6 @@ std::unique_ptr<fcitx::CommonCandidateList> Engine::makeCandidateList() {
   candidateList->setPageSize(instance_->globalConfig().defaultPageSize());
 
   return candidateList;
-}
-
-bool Engine::keep(fcitx::KeyEvent &event) {
-  // Regardless whether we are in an input session, we do not keep.
-  if (event.isRelease() || event.key().isModifier() || event.key().isUAZ()) {
-    return false;
-  }
-
-  if (inSession()) {
-    return true;
-  }
-
-  // Not in an input session
-  if (event.key().checkKeyList(outOfSessionSkip)) {
-    return false;
-  }
-  return true;
 }
 
 Server::Server() {
@@ -185,12 +144,6 @@ void Server::dispatch(CommandToFcitx *cmd) {
   dispatcher->schedule([engine = engine, cmd = *cmd]() {
     auto ic = engine->getInputContext();
     ic->inputPanel().reset();
-
-    if (cmd.has_update_session_status()) {
-      auto inSession = cmd.update_session_status().in_session();
-      engine->inSession(inSession);
-      return;
-    }
 
     if (cmd.has_commit_text()) {
       auto text = cmd.commit_text().text();

--- a/bridge.h
+++ b/bridge.h
@@ -36,9 +36,6 @@ public:
   void reset(const fcitx::InputMethodEntry &,
              fcitx::InputContextEvent &event) override;
 
-  void inSession(const bool isInSession);
-  bool inSession();
-
   fcitx::InputContext *getInputContext();
   fcitx::Instance *getInstance();
   std::unique_ptr<fcitx::CommonCandidateList> makeCandidateList();
@@ -50,10 +47,6 @@ private:
   zmq::socket_t *pub;
   Server *server;
   fcitx::EventDispatcher *dispatcher;
-  bool isInSession;
-  std::shared_mutex mtxInSession;
-
-  bool keep(fcitx::KeyEvent &event);
 };
 
 class Server {

--- a/bridge.h
+++ b/bridge.h
@@ -44,7 +44,7 @@ private:
   fcitx::Instance *instance_;
   fcitx::InputContext *ic;
   zmq::context_t *ctx;
-  zmq::socket_t *pub;
+  zmq::socket_t *sock;
   Server *server;
   fcitx::EventDispatcher *dispatcher;
 };
@@ -59,7 +59,7 @@ public:
 
 private:
   zmq::context_t *ctx;
-  zmq::socket_t *rep;
+  zmq::socket_t *sock;
   Engine *engine;
   fcitx::EventDispatcher *dispatcher;
   void dispatch(CommandToFcitx *);

--- a/msgs.pb.cc
+++ b/msgs.pb.cc
@@ -61,6 +61,25 @@ struct UpdateCandidatesDefaultTypeInternal {
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 UpdateCandidatesDefaultTypeInternal _UpdateCandidates_default_instance_;
 
+inline constexpr KeyEventReply::Impl_::Impl_(
+    ::_pbi::ConstantInitialized) noexcept
+      : accepted_{false},
+        _cached_size_{0} {}
+
+template <typename>
+PROTOBUF_CONSTEXPR KeyEventReply::KeyEventReply(::_pbi::ConstantInitialized)
+    : _impl_(::_pbi::ConstantInitialized()) {}
+struct KeyEventReplyDefaultTypeInternal {
+  PROTOBUF_CONSTEXPR KeyEventReplyDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
+  ~KeyEventReplyDefaultTypeInternal() {}
+  union {
+    KeyEventReply _instance;
+  };
+};
+
+PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
+    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 KeyEventReplyDefaultTypeInternal _KeyEventReply_default_instance_;
+
 inline constexpr KeyEvent::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : key_{0u},
@@ -120,7 +139,7 @@ struct CommandToFcitxDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 CommandToFcitxDefaultTypeInternal _CommandToFcitx_default_instance_;
-static ::_pb::Metadata file_level_metadata_msgs_2eproto[5];
+static ::_pb::Metadata file_level_metadata_msgs_2eproto[6];
 static constexpr const ::_pb::EnumDescriptor**
     file_level_enum_descriptors_msgs_2eproto = nullptr;
 static constexpr const ::_pb::ServiceDescriptor**
@@ -175,6 +194,15 @@ const ::uint32_t TableStruct_msgs_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(
     ~0u,  // no _split_
     ~0u,  // no sizeof(Split)
     PROTOBUF_FIELD_OFFSET(::KeyEvent, _impl_.key_),
+    ~0u,  // no _has_bits_
+    PROTOBUF_FIELD_OFFSET(::KeyEventReply, _internal_metadata_),
+    ~0u,  // no _extensions_
+    ~0u,  // no _oneof_case_
+    ~0u,  // no _weak_field_map_
+    ~0u,  // no _inlined_string_donated_
+    ~0u,  // no _split_
+    ~0u,  // no sizeof(Split)
+    PROTOBUF_FIELD_OFFSET(::KeyEventReply, _impl_.accepted_),
 };
 
 static const ::_pbi::MigrationSchema
@@ -184,6 +212,7 @@ static const ::_pbi::MigrationSchema
         {21, -1, -1, sizeof(::UpdatePreedit)},
         {30, -1, -1, sizeof(::UpdateCandidates)},
         {39, -1, -1, sizeof(::KeyEvent)},
+        {48, -1, -1, sizeof(::KeyEventReply)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
@@ -192,6 +221,7 @@ static const ::_pb::Message* const file_default_instances[] = {
     &::_UpdatePreedit_default_instance_._instance,
     &::_UpdateCandidates_default_instance_._instance,
     &::_KeyEvent_default_instance_._instance,
+    &::_KeyEventReply_default_instance_._instance,
 };
 const char descriptor_table_protodef_msgs_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
     "\n\nmsgs.proto\"\231\001\n\016CommandToFcitx\022\"\n\013commi"
@@ -201,19 +231,20 @@ const char descriptor_table_protodef_msgs_2eproto[] PROTOBUF_SECTION_VARIABLE(pr
     "\007command\"\032\n\nCommitText\022\014\n\004text\030\001 \001(\t\"\035\n\r"
     "UpdatePreedit\022\014\n\004text\030\001 \001(\t\"&\n\020UpdateCan"
     "didates\022\022\n\ncandidates\030\001 \003(\t\"\027\n\010KeyEvent\022"
-    "\013\n\003key\030\001 \001(\rb\006proto3"
+    "\013\n\003key\030\001 \001(\r\"!\n\rKeyEventReply\022\020\n\010accepte"
+    "d\030\001 \001(\010b\006proto3"
 };
 static ::absl::once_flag descriptor_table_msgs_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_msgs_2eproto = {
     false,
     false,
-    300,
+    335,
     descriptor_table_protodef_msgs_2eproto,
     "msgs.proto",
     &descriptor_table_msgs_2eproto_once,
     nullptr,
     0,
-    5,
+    6,
     schemas,
     file_default_instances,
     TableStruct_msgs_2eproto::offsets,
@@ -1313,6 +1344,175 @@ void KeyEvent::InternalSwap(KeyEvent* PROTOBUF_RESTRICT other) {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_msgs_2eproto_getter, &descriptor_table_msgs_2eproto_once,
       file_level_metadata_msgs_2eproto[4]);
+}
+// ===================================================================
+
+class KeyEventReply::_Internal {
+ public:
+};
+
+KeyEventReply::KeyEventReply(::google::protobuf::Arena* arena)
+    : ::google::protobuf::Message(arena) {
+  SharedCtor(arena);
+  // @@protoc_insertion_point(arena_constructor:KeyEventReply)
+}
+KeyEventReply::KeyEventReply(
+    ::google::protobuf::Arena* arena, const KeyEventReply& from)
+    : KeyEventReply(arena) {
+  MergeFrom(from);
+}
+inline PROTOBUF_NDEBUG_INLINE KeyEventReply::Impl_::Impl_(
+    ::google::protobuf::internal::InternalVisibility visibility,
+    ::google::protobuf::Arena* arena)
+      : _cached_size_{0} {}
+
+inline void KeyEventReply::SharedCtor(::_pb::Arena* arena) {
+  new (&_impl_) Impl_(internal_visibility(), arena);
+  _impl_.accepted_ = {};
+}
+KeyEventReply::~KeyEventReply() {
+  // @@protoc_insertion_point(destructor:KeyEventReply)
+  _internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
+  SharedDtor();
+}
+inline void KeyEventReply::SharedDtor() {
+  ABSL_DCHECK(GetArena() == nullptr);
+  _impl_.~Impl_();
+}
+
+PROTOBUF_NOINLINE void KeyEventReply::Clear() {
+// @@protoc_insertion_point(message_clear_start:KeyEventReply)
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  _impl_.accepted_ = false;
+  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
+}
+
+const char* KeyEventReply::_InternalParse(
+    const char* ptr, ::_pbi::ParseContext* ctx) {
+  ptr = ::_pbi::TcParser::ParseLoop(this, ptr, ctx, &_table_.header);
+  return ptr;
+}
+
+
+PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
+const ::_pbi::TcParseTable<0, 1, 0, 0, 2> KeyEventReply::_table_ = {
+  {
+    0,  // no _has_bits_
+    0, // no _extensions_
+    1, 0,  // max_field_number, fast_idx_mask
+    offsetof(decltype(_table_), field_lookup_table),
+    4294967294,  // skipmap
+    offsetof(decltype(_table_), field_entries),
+    1,  // num_field_entries
+    0,  // num_aux_entries
+    offsetof(decltype(_table_), field_names),  // no aux_entries
+    &_KeyEventReply_default_instance_._instance,
+    ::_pbi::TcParser::GenericFallback,  // fallback
+  }, {{
+    // bool accepted = 1;
+    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(KeyEventReply, _impl_.accepted_), 63>(),
+     {8, 63, 0, PROTOBUF_FIELD_OFFSET(KeyEventReply, _impl_.accepted_)}},
+  }}, {{
+    65535, 65535
+  }}, {{
+    // bool accepted = 1;
+    {PROTOBUF_FIELD_OFFSET(KeyEventReply, _impl_.accepted_), 0, 0,
+    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
+  }},
+  // no aux_entries
+  {{
+  }},
+};
+
+::uint8_t* KeyEventReply::_InternalSerialize(
+    ::uint8_t* target,
+    ::google::protobuf::io::EpsCopyOutputStream* stream) const {
+  // @@protoc_insertion_point(serialize_to_array_start:KeyEventReply)
+  ::uint32_t cached_has_bits = 0;
+  (void)cached_has_bits;
+
+  // bool accepted = 1;
+  if (this->_internal_accepted() != 0) {
+    target = stream->EnsureSpace(target);
+    target = ::_pbi::WireFormatLite::WriteBoolToArray(
+        1, this->_internal_accepted(), target);
+  }
+
+  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
+    target =
+        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
+            _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
+  }
+  // @@protoc_insertion_point(serialize_to_array_end:KeyEventReply)
+  return target;
+}
+
+::size_t KeyEventReply::ByteSizeLong() const {
+// @@protoc_insertion_point(message_byte_size_start:KeyEventReply)
+  ::size_t total_size = 0;
+
+  ::uint32_t cached_has_bits = 0;
+  // Prevent compiler warnings about cached_has_bits being unused
+  (void) cached_has_bits;
+
+  // bool accepted = 1;
+  if (this->_internal_accepted() != 0) {
+    total_size += 2;
+  }
+
+  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
+}
+
+const ::google::protobuf::Message::ClassData KeyEventReply::_class_data_ = {
+    KeyEventReply::MergeImpl,
+    nullptr,  // OnDemandRegisterArenaDtor
+};
+const ::google::protobuf::Message::ClassData* KeyEventReply::GetClassData() const {
+  return &_class_data_;
+}
+
+void KeyEventReply::MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg) {
+  auto* const _this = static_cast<KeyEventReply*>(&to_msg);
+  auto& from = static_cast<const KeyEventReply&>(from_msg);
+  // @@protoc_insertion_point(class_specific_merge_from_start:KeyEventReply)
+  ABSL_DCHECK_NE(&from, _this);
+  ::uint32_t cached_has_bits = 0;
+  (void) cached_has_bits;
+
+  if (from._internal_accepted() != 0) {
+    _this->_internal_set_accepted(from._internal_accepted());
+  }
+  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
+}
+
+void KeyEventReply::CopyFrom(const KeyEventReply& from) {
+// @@protoc_insertion_point(class_specific_copy_from_start:KeyEventReply)
+  if (&from == this) return;
+  Clear();
+  MergeFrom(from);
+}
+
+PROTOBUF_NOINLINE bool KeyEventReply::IsInitialized() const {
+  return true;
+}
+
+::_pbi::CachedSize* KeyEventReply::AccessCachedSize() const {
+  return &_impl_._cached_size_;
+}
+void KeyEventReply::InternalSwap(KeyEventReply* PROTOBUF_RESTRICT other) {
+  using std::swap;
+  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
+        swap(_impl_.accepted_, other->_impl_.accepted_);
+}
+
+::google::protobuf::Metadata KeyEventReply::GetMetadata() const {
+  return ::_pbi::AssignDescriptors(
+      &descriptor_table_msgs_2eproto_getter, &descriptor_table_msgs_2eproto_once,
+      file_level_metadata_msgs_2eproto[5]);
 }
 // @@protoc_insertion_point(namespace_scope)
 namespace google {

--- a/msgs.pb.cc
+++ b/msgs.pb.cc
@@ -21,25 +21,6 @@ namespace _pb = ::google::protobuf;
 namespace _pbi = ::google::protobuf::internal;
 namespace _fl = ::google::protobuf::internal::field_layout;
 
-inline constexpr UpdateSessionStatus::Impl_::Impl_(
-    ::_pbi::ConstantInitialized) noexcept
-      : in_session_{false},
-        _cached_size_{0} {}
-
-template <typename>
-PROTOBUF_CONSTEXPR UpdateSessionStatus::UpdateSessionStatus(::_pbi::ConstantInitialized)
-    : _impl_(::_pbi::ConstantInitialized()) {}
-struct UpdateSessionStatusDefaultTypeInternal {
-  PROTOBUF_CONSTEXPR UpdateSessionStatusDefaultTypeInternal() : _instance(::_pbi::ConstantInitialized{}) {}
-  ~UpdateSessionStatusDefaultTypeInternal() {}
-  union {
-    UpdateSessionStatus _instance;
-  };
-};
-
-PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
-    PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 UpdateSessionStatusDefaultTypeInternal _UpdateSessionStatus_default_instance_;
-
 inline constexpr UpdatePreedit::Impl_::Impl_(
     ::_pbi::ConstantInitialized) noexcept
       : text_(
@@ -139,7 +120,7 @@ struct CommandToFcitxDefaultTypeInternal {
 
 PROTOBUF_ATTRIBUTE_NO_DESTROY PROTOBUF_CONSTINIT
     PROTOBUF_ATTRIBUTE_INIT_PRIORITY1 CommandToFcitxDefaultTypeInternal _CommandToFcitx_default_instance_;
-static ::_pb::Metadata file_level_metadata_msgs_2eproto[6];
+static ::_pb::Metadata file_level_metadata_msgs_2eproto[5];
 static constexpr const ::_pb::EnumDescriptor**
     file_level_enum_descriptors_msgs_2eproto = nullptr;
 static constexpr const ::_pb::ServiceDescriptor**
@@ -154,7 +135,6 @@ const ::uint32_t TableStruct_msgs_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(
     ~0u,  // no _inlined_string_donated_
     ~0u,  // no _split_
     ~0u,  // no sizeof(Split)
-    ::_pbi::kInvalidFieldOffsetTag,
     ::_pbi::kInvalidFieldOffsetTag,
     ::_pbi::kInvalidFieldOffsetTag,
     ::_pbi::kInvalidFieldOffsetTag,
@@ -178,15 +158,6 @@ const ::uint32_t TableStruct_msgs_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(
     ~0u,  // no sizeof(Split)
     PROTOBUF_FIELD_OFFSET(::UpdatePreedit, _impl_.text_),
     ~0u,  // no _has_bits_
-    PROTOBUF_FIELD_OFFSET(::UpdateSessionStatus, _internal_metadata_),
-    ~0u,  // no _extensions_
-    ~0u,  // no _oneof_case_
-    ~0u,  // no _weak_field_map_
-    ~0u,  // no _inlined_string_donated_
-    ~0u,  // no _split_
-    ~0u,  // no sizeof(Split)
-    PROTOBUF_FIELD_OFFSET(::UpdateSessionStatus, _impl_.in_session_),
-    ~0u,  // no _has_bits_
     PROTOBUF_FIELD_OFFSET(::UpdateCandidates, _internal_metadata_),
     ~0u,  // no _extensions_
     ~0u,  // no _oneof_case_
@@ -209,44 +180,40 @@ const ::uint32_t TableStruct_msgs_2eproto::offsets[] PROTOBUF_SECTION_VARIABLE(
 static const ::_pbi::MigrationSchema
     schemas[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
         {0, -1, -1, sizeof(::CommandToFcitx)},
-        {13, -1, -1, sizeof(::CommitText)},
-        {22, -1, -1, sizeof(::UpdatePreedit)},
-        {31, -1, -1, sizeof(::UpdateSessionStatus)},
-        {40, -1, -1, sizeof(::UpdateCandidates)},
-        {49, -1, -1, sizeof(::KeyEvent)},
+        {12, -1, -1, sizeof(::CommitText)},
+        {21, -1, -1, sizeof(::UpdatePreedit)},
+        {30, -1, -1, sizeof(::UpdateCandidates)},
+        {39, -1, -1, sizeof(::KeyEvent)},
 };
 
 static const ::_pb::Message* const file_default_instances[] = {
     &::_CommandToFcitx_default_instance_._instance,
     &::_CommitText_default_instance_._instance,
     &::_UpdatePreedit_default_instance_._instance,
-    &::_UpdateSessionStatus_default_instance_._instance,
     &::_UpdateCandidates_default_instance_._instance,
     &::_KeyEvent_default_instance_._instance,
 };
 const char descriptor_table_protodef_msgs_2eproto[] PROTOBUF_SECTION_VARIABLE(protodesc_cold) = {
-    "\n\nmsgs.proto\"\320\001\n\016CommandToFcitx\0225\n\025updat"
-    "e_session_status\030\001 \001(\0132\024.UpdateSessionSt"
-    "atusH\000\022\"\n\013commit_text\030\002 \001(\0132\013.CommitText"
-    "H\000\022(\n\016update_preedit\030\003 \001(\0132\016.UpdatePreed"
-    "itH\000\022.\n\021update_candidates\030\004 \001(\0132\021.Update"
-    "CandidatesH\000B\t\n\007command\"\032\n\nCommitText\022\014\n"
-    "\004text\030\001 \001(\t\"\035\n\rUpdatePreedit\022\014\n\004text\030\001 \001"
-    "(\t\")\n\023UpdateSessionStatus\022\022\n\nin_session\030"
-    "\001 \001(\010\"&\n\020UpdateCandidates\022\022\n\ncandidates\030"
-    "\001 \003(\t\"\027\n\010KeyEvent\022\013\n\003key\030\001 \001(\rb\006proto3"
+    "\n\nmsgs.proto\"\231\001\n\016CommandToFcitx\022\"\n\013commi"
+    "t_text\030\002 \001(\0132\013.CommitTextH\000\022(\n\016update_pr"
+    "eedit\030\003 \001(\0132\016.UpdatePreeditH\000\022.\n\021update_"
+    "candidates\030\004 \001(\0132\021.UpdateCandidatesH\000B\t\n"
+    "\007command\"\032\n\nCommitText\022\014\n\004text\030\001 \001(\t\"\035\n\r"
+    "UpdatePreedit\022\014\n\004text\030\001 \001(\t\"&\n\020UpdateCan"
+    "didates\022\022\n\ncandidates\030\001 \003(\t\"\027\n\010KeyEvent\022"
+    "\013\n\003key\030\001 \001(\rb\006proto3"
 };
 static ::absl::once_flag descriptor_table_msgs_2eproto_once;
 const ::_pbi::DescriptorTable descriptor_table_msgs_2eproto = {
     false,
     false,
-    398,
+    300,
     descriptor_table_protodef_msgs_2eproto,
     "msgs.proto",
     &descriptor_table_msgs_2eproto_once,
     nullptr,
     0,
-    6,
+    5,
     schemas,
     file_default_instances,
     TableStruct_msgs_2eproto::offsets,
@@ -278,15 +245,11 @@ class CommandToFcitx::_Internal {
  public:
   static constexpr ::int32_t kOneofCaseOffset =
     PROTOBUF_FIELD_OFFSET(::CommandToFcitx, _impl_._oneof_case_);
-  static const ::UpdateSessionStatus& update_session_status(const CommandToFcitx* msg);
   static const ::CommitText& commit_text(const CommandToFcitx* msg);
   static const ::UpdatePreedit& update_preedit(const CommandToFcitx* msg);
   static const ::UpdateCandidates& update_candidates(const CommandToFcitx* msg);
 };
 
-const ::UpdateSessionStatus& CommandToFcitx::_Internal::update_session_status(const CommandToFcitx* msg) {
-  return *msg->_impl_.command_.update_session_status_;
-}
 const ::CommitText& CommandToFcitx::_Internal::commit_text(const CommandToFcitx* msg) {
   return *msg->_impl_.command_.commit_text_;
 }
@@ -295,19 +258,6 @@ const ::UpdatePreedit& CommandToFcitx::_Internal::update_preedit(const CommandTo
 }
 const ::UpdateCandidates& CommandToFcitx::_Internal::update_candidates(const CommandToFcitx* msg) {
   return *msg->_impl_.command_.update_candidates_;
-}
-void CommandToFcitx::set_allocated_update_session_status(::UpdateSessionStatus* update_session_status) {
-  ::google::protobuf::Arena* message_arena = GetArena();
-  clear_command();
-  if (update_session_status) {
-    ::google::protobuf::Arena* submessage_arena = update_session_status->GetArena();
-    if (message_arena != submessage_arena) {
-      update_session_status = ::google::protobuf::internal::GetOwnedMessage(message_arena, update_session_status, submessage_arena);
-    }
-    set_has_update_session_status();
-    _impl_.command_.update_session_status_ = update_session_status;
-  }
-  // @@protoc_insertion_point(field_set_allocated:CommandToFcitx.update_session_status)
 }
 void CommandToFcitx::set_allocated_commit_text(::CommitText* commit_text) {
   ::google::protobuf::Arena* message_arena = GetArena();
@@ -372,9 +322,6 @@ CommandToFcitx::CommandToFcitx(
   switch (command_case()) {
     case COMMAND_NOT_SET:
       break;
-      case kUpdateSessionStatus:
-        _impl_.command_.update_session_status_ = CreateMaybeMessage<::UpdateSessionStatus>(arena, *from._impl_.command_.update_session_status_);
-        break;
       case kCommitText:
         _impl_.command_.commit_text_ = CreateMaybeMessage<::CommitText>(arena, *from._impl_.command_.commit_text_);
         break;
@@ -415,12 +362,6 @@ void CommandToFcitx::clear_command() {
 // @@protoc_insertion_point(one_of_clear_start:CommandToFcitx)
   PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
   switch (command_case()) {
-    case kUpdateSessionStatus: {
-      if (GetArena() == nullptr) {
-        delete _impl_.command_.update_session_status_;
-      }
-      break;
-    }
     case kCommitText: {
       if (GetArena() == nullptr) {
         delete _impl_.command_.commit_text_;
@@ -466,16 +407,16 @@ const char* CommandToFcitx::_InternalParse(
 
 
 PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<0, 4, 4, 0, 2> CommandToFcitx::_table_ = {
+const ::_pbi::TcParseTable<0, 3, 3, 0, 2> CommandToFcitx::_table_ = {
   {
     0,  // no _has_bits_
     0, // no _extensions_
     4, 0,  // max_field_number, fast_idx_mask
     offsetof(decltype(_table_), field_lookup_table),
-    4294967280,  // skipmap
+    4294967281,  // skipmap
     offsetof(decltype(_table_), field_entries),
-    4,  // num_field_entries
-    4,  // num_aux_entries
+    3,  // num_field_entries
+    3,  // num_aux_entries
     offsetof(decltype(_table_), aux_entries),
     &_CommandToFcitx_default_instance_._instance,
     ::_pbi::TcParser::GenericFallback,  // fallback
@@ -484,20 +425,16 @@ const ::_pbi::TcParseTable<0, 4, 4, 0, 2> CommandToFcitx::_table_ = {
   }}, {{
     65535, 65535
   }}, {{
-    // .UpdateSessionStatus update_session_status = 1;
-    {PROTOBUF_FIELD_OFFSET(CommandToFcitx, _impl_.command_.update_session_status_), _Internal::kOneofCaseOffset + 0, 0,
-    (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
     // .CommitText commit_text = 2;
-    {PROTOBUF_FIELD_OFFSET(CommandToFcitx, _impl_.command_.commit_text_), _Internal::kOneofCaseOffset + 0, 1,
+    {PROTOBUF_FIELD_OFFSET(CommandToFcitx, _impl_.command_.commit_text_), _Internal::kOneofCaseOffset + 0, 0,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
     // .UpdatePreedit update_preedit = 3;
-    {PROTOBUF_FIELD_OFFSET(CommandToFcitx, _impl_.command_.update_preedit_), _Internal::kOneofCaseOffset + 0, 2,
+    {PROTOBUF_FIELD_OFFSET(CommandToFcitx, _impl_.command_.update_preedit_), _Internal::kOneofCaseOffset + 0, 1,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
     // .UpdateCandidates update_candidates = 4;
-    {PROTOBUF_FIELD_OFFSET(CommandToFcitx, _impl_.command_.update_candidates_), _Internal::kOneofCaseOffset + 0, 3,
+    {PROTOBUF_FIELD_OFFSET(CommandToFcitx, _impl_.command_.update_candidates_), _Internal::kOneofCaseOffset + 0, 2,
     (0 | ::_fl::kFcOneof | ::_fl::kMessage | ::_fl::kTvTable)},
   }}, {{
-    {::_pbi::TcParser::GetTable<::UpdateSessionStatus>()},
     {::_pbi::TcParser::GetTable<::CommitText>()},
     {::_pbi::TcParser::GetTable<::UpdatePreedit>()},
     {::_pbi::TcParser::GetTable<::UpdateCandidates>()},
@@ -513,12 +450,6 @@ const ::_pbi::TcParseTable<0, 4, 4, 0, 2> CommandToFcitx::_table_ = {
   (void)cached_has_bits;
 
   switch (command_case()) {
-    case kUpdateSessionStatus: {
-      target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
-          1, _Internal::update_session_status(this),
-          _Internal::update_session_status(this).GetCachedSize(), target, stream);
-      break;
-    }
     case kCommitText: {
       target = ::google::protobuf::internal::WireFormatLite::InternalWriteMessage(
           2, _Internal::commit_text(this),
@@ -558,12 +489,6 @@ const ::_pbi::TcParseTable<0, 4, 4, 0, 2> CommandToFcitx::_table_ = {
   (void) cached_has_bits;
 
   switch (command_case()) {
-    // .UpdateSessionStatus update_session_status = 1;
-    case kUpdateSessionStatus: {
-      total_size +=
-          1 + ::google::protobuf::internal::WireFormatLite::MessageSize(*_impl_.command_.update_session_status_);
-      break;
-    }
     // .CommitText commit_text = 2;
     case kCommitText: {
       total_size +=
@@ -606,11 +531,6 @@ void CommandToFcitx::MergeImpl(::google::protobuf::Message& to_msg, const ::goog
   (void) cached_has_bits;
 
   switch (from.command_case()) {
-    case kUpdateSessionStatus: {
-      _this->_internal_mutable_update_session_status()->::UpdateSessionStatus::MergeFrom(
-          from._internal_update_session_status());
-      break;
-    }
     case kCommitText: {
       _this->_internal_mutable_commit_text()->::CommitText::MergeFrom(
           from._internal_commit_text());
@@ -1041,175 +961,6 @@ void UpdatePreedit::InternalSwap(UpdatePreedit* PROTOBUF_RESTRICT other) {
 }
 // ===================================================================
 
-class UpdateSessionStatus::_Internal {
- public:
-};
-
-UpdateSessionStatus::UpdateSessionStatus(::google::protobuf::Arena* arena)
-    : ::google::protobuf::Message(arena) {
-  SharedCtor(arena);
-  // @@protoc_insertion_point(arena_constructor:UpdateSessionStatus)
-}
-UpdateSessionStatus::UpdateSessionStatus(
-    ::google::protobuf::Arena* arena, const UpdateSessionStatus& from)
-    : UpdateSessionStatus(arena) {
-  MergeFrom(from);
-}
-inline PROTOBUF_NDEBUG_INLINE UpdateSessionStatus::Impl_::Impl_(
-    ::google::protobuf::internal::InternalVisibility visibility,
-    ::google::protobuf::Arena* arena)
-      : _cached_size_{0} {}
-
-inline void UpdateSessionStatus::SharedCtor(::_pb::Arena* arena) {
-  new (&_impl_) Impl_(internal_visibility(), arena);
-  _impl_.in_session_ = {};
-}
-UpdateSessionStatus::~UpdateSessionStatus() {
-  // @@protoc_insertion_point(destructor:UpdateSessionStatus)
-  _internal_metadata_.Delete<::google::protobuf::UnknownFieldSet>();
-  SharedDtor();
-}
-inline void UpdateSessionStatus::SharedDtor() {
-  ABSL_DCHECK(GetArena() == nullptr);
-  _impl_.~Impl_();
-}
-
-PROTOBUF_NOINLINE void UpdateSessionStatus::Clear() {
-// @@protoc_insertion_point(message_clear_start:UpdateSessionStatus)
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  ::uint32_t cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  _impl_.in_session_ = false;
-  _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
-}
-
-const char* UpdateSessionStatus::_InternalParse(
-    const char* ptr, ::_pbi::ParseContext* ctx) {
-  ptr = ::_pbi::TcParser::ParseLoop(this, ptr, ctx, &_table_.header);
-  return ptr;
-}
-
-
-PROTOBUF_CONSTINIT PROTOBUF_ATTRIBUTE_INIT_PRIORITY1
-const ::_pbi::TcParseTable<0, 1, 0, 0, 2> UpdateSessionStatus::_table_ = {
-  {
-    0,  // no _has_bits_
-    0, // no _extensions_
-    1, 0,  // max_field_number, fast_idx_mask
-    offsetof(decltype(_table_), field_lookup_table),
-    4294967294,  // skipmap
-    offsetof(decltype(_table_), field_entries),
-    1,  // num_field_entries
-    0,  // num_aux_entries
-    offsetof(decltype(_table_), field_names),  // no aux_entries
-    &_UpdateSessionStatus_default_instance_._instance,
-    ::_pbi::TcParser::GenericFallback,  // fallback
-  }, {{
-    // bool in_session = 1;
-    {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(UpdateSessionStatus, _impl_.in_session_), 63>(),
-     {8, 63, 0, PROTOBUF_FIELD_OFFSET(UpdateSessionStatus, _impl_.in_session_)}},
-  }}, {{
-    65535, 65535
-  }}, {{
-    // bool in_session = 1;
-    {PROTOBUF_FIELD_OFFSET(UpdateSessionStatus, _impl_.in_session_), 0, 0,
-    (0 | ::_fl::kFcSingular | ::_fl::kBool)},
-  }},
-  // no aux_entries
-  {{
-  }},
-};
-
-::uint8_t* UpdateSessionStatus::_InternalSerialize(
-    ::uint8_t* target,
-    ::google::protobuf::io::EpsCopyOutputStream* stream) const {
-  // @@protoc_insertion_point(serialize_to_array_start:UpdateSessionStatus)
-  ::uint32_t cached_has_bits = 0;
-  (void)cached_has_bits;
-
-  // bool in_session = 1;
-  if (this->_internal_in_session() != 0) {
-    target = stream->EnsureSpace(target);
-    target = ::_pbi::WireFormatLite::WriteBoolToArray(
-        1, this->_internal_in_session(), target);
-  }
-
-  if (PROTOBUF_PREDICT_FALSE(_internal_metadata_.have_unknown_fields())) {
-    target =
-        ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
-            _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance), target, stream);
-  }
-  // @@protoc_insertion_point(serialize_to_array_end:UpdateSessionStatus)
-  return target;
-}
-
-::size_t UpdateSessionStatus::ByteSizeLong() const {
-// @@protoc_insertion_point(message_byte_size_start:UpdateSessionStatus)
-  ::size_t total_size = 0;
-
-  ::uint32_t cached_has_bits = 0;
-  // Prevent compiler warnings about cached_has_bits being unused
-  (void) cached_has_bits;
-
-  // bool in_session = 1;
-  if (this->_internal_in_session() != 0) {
-    total_size += 2;
-  }
-
-  return MaybeComputeUnknownFieldsSize(total_size, &_impl_._cached_size_);
-}
-
-const ::google::protobuf::Message::ClassData UpdateSessionStatus::_class_data_ = {
-    UpdateSessionStatus::MergeImpl,
-    nullptr,  // OnDemandRegisterArenaDtor
-};
-const ::google::protobuf::Message::ClassData* UpdateSessionStatus::GetClassData() const {
-  return &_class_data_;
-}
-
-void UpdateSessionStatus::MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg) {
-  auto* const _this = static_cast<UpdateSessionStatus*>(&to_msg);
-  auto& from = static_cast<const UpdateSessionStatus&>(from_msg);
-  // @@protoc_insertion_point(class_specific_merge_from_start:UpdateSessionStatus)
-  ABSL_DCHECK_NE(&from, _this);
-  ::uint32_t cached_has_bits = 0;
-  (void) cached_has_bits;
-
-  if (from._internal_in_session() != 0) {
-    _this->_internal_set_in_session(from._internal_in_session());
-  }
-  _this->_internal_metadata_.MergeFrom<::google::protobuf::UnknownFieldSet>(from._internal_metadata_);
-}
-
-void UpdateSessionStatus::CopyFrom(const UpdateSessionStatus& from) {
-// @@protoc_insertion_point(class_specific_copy_from_start:UpdateSessionStatus)
-  if (&from == this) return;
-  Clear();
-  MergeFrom(from);
-}
-
-PROTOBUF_NOINLINE bool UpdateSessionStatus::IsInitialized() const {
-  return true;
-}
-
-::_pbi::CachedSize* UpdateSessionStatus::AccessCachedSize() const {
-  return &_impl_._cached_size_;
-}
-void UpdateSessionStatus::InternalSwap(UpdateSessionStatus* PROTOBUF_RESTRICT other) {
-  using std::swap;
-  _internal_metadata_.InternalSwap(&other->_internal_metadata_);
-        swap(_impl_.in_session_, other->_impl_.in_session_);
-}
-
-::google::protobuf::Metadata UpdateSessionStatus::GetMetadata() const {
-  return ::_pbi::AssignDescriptors(
-      &descriptor_table_msgs_2eproto_getter, &descriptor_table_msgs_2eproto_once,
-      file_level_metadata_msgs_2eproto[3]);
-}
-// ===================================================================
-
 class UpdateCandidates::_Internal {
  public:
 };
@@ -1391,7 +1142,7 @@ void UpdateCandidates::InternalSwap(UpdateCandidates* PROTOBUF_RESTRICT other) {
 ::google::protobuf::Metadata UpdateCandidates::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_msgs_2eproto_getter, &descriptor_table_msgs_2eproto_once,
-      file_level_metadata_msgs_2eproto[4]);
+      file_level_metadata_msgs_2eproto[3]);
 }
 // ===================================================================
 
@@ -1561,7 +1312,7 @@ void KeyEvent::InternalSwap(KeyEvent* PROTOBUF_RESTRICT other) {
 ::google::protobuf::Metadata KeyEvent::GetMetadata() const {
   return ::_pbi::AssignDescriptors(
       &descriptor_table_msgs_2eproto_getter, &descriptor_table_msgs_2eproto_once,
-      file_level_metadata_msgs_2eproto[5]);
+      file_level_metadata_msgs_2eproto[4]);
 }
 // @@protoc_insertion_point(namespace_scope)
 namespace google {

--- a/msgs.pb.h
+++ b/msgs.pb.h
@@ -64,6 +64,9 @@ extern CommitTextDefaultTypeInternal _CommitText_default_instance_;
 class KeyEvent;
 struct KeyEventDefaultTypeInternal;
 extern KeyEventDefaultTypeInternal _KeyEvent_default_instance_;
+class KeyEventReply;
+struct KeyEventReplyDefaultTypeInternal;
+extern KeyEventReplyDefaultTypeInternal _KeyEventReply_default_instance_;
 class UpdateCandidates;
 struct UpdateCandidatesDefaultTypeInternal;
 extern UpdateCandidatesDefaultTypeInternal _UpdateCandidates_default_instance_;
@@ -448,6 +451,181 @@ class UpdateCandidates final :
         inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
                               ::google::protobuf::Arena* arena, const Impl_& from);
     ::google::protobuf::RepeatedPtrField<std::string> candidates_;
+    mutable ::google::protobuf::internal::CachedSize _cached_size_;
+    PROTOBUF_TSAN_DECLARE_MEMBER
+  };
+  union { Impl_ _impl_; };
+  friend struct ::TableStruct_msgs_2eproto;
+};// -------------------------------------------------------------------
+
+class KeyEventReply final :
+    public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:KeyEventReply) */ {
+ public:
+  inline KeyEventReply() : KeyEventReply(nullptr) {}
+  ~KeyEventReply() override;
+  template<typename = void>
+  explicit PROTOBUF_CONSTEXPR KeyEventReply(::google::protobuf::internal::ConstantInitialized);
+
+  inline KeyEventReply(const KeyEventReply& from)
+      : KeyEventReply(nullptr, from) {}
+  KeyEventReply(KeyEventReply&& from) noexcept
+    : KeyEventReply() {
+    *this = ::std::move(from);
+  }
+
+  inline KeyEventReply& operator=(const KeyEventReply& from) {
+    CopyFrom(from);
+    return *this;
+  }
+  inline KeyEventReply& operator=(KeyEventReply&& from) noexcept {
+    if (this == &from) return *this;
+    if (GetArena() == from.GetArena()
+  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
+        && GetArena() != nullptr
+  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
+    ) {
+      InternalSwap(&from);
+    } else {
+      CopyFrom(from);
+    }
+    return *this;
+  }
+
+  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
+  }
+  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
+      ABSL_ATTRIBUTE_LIFETIME_BOUND {
+    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
+  }
+
+  static const ::google::protobuf::Descriptor* descriptor() {
+    return GetDescriptor();
+  }
+  static const ::google::protobuf::Descriptor* GetDescriptor() {
+    return default_instance().GetMetadata().descriptor;
+  }
+  static const ::google::protobuf::Reflection* GetReflection() {
+    return default_instance().GetMetadata().reflection;
+  }
+  static const KeyEventReply& default_instance() {
+    return *internal_default_instance();
+  }
+  static inline const KeyEventReply* internal_default_instance() {
+    return reinterpret_cast<const KeyEventReply*>(
+               &_KeyEventReply_default_instance_);
+  }
+  static constexpr int kIndexInFileMessages =
+    5;
+
+  friend void swap(KeyEventReply& a, KeyEventReply& b) {
+    a.Swap(&b);
+  }
+  inline void Swap(KeyEventReply* other) {
+    if (other == this) return;
+  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() != nullptr &&
+        GetArena() == other->GetArena()) {
+   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
+    if (GetArena() == other->GetArena()) {
+  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
+      InternalSwap(other);
+    } else {
+      ::google::protobuf::internal::GenericSwap(this, other);
+    }
+  }
+  void UnsafeArenaSwap(KeyEventReply* other) {
+    if (other == this) return;
+    ABSL_DCHECK(GetArena() == other->GetArena());
+    InternalSwap(other);
+  }
+
+  // implements Message ----------------------------------------------
+
+  KeyEventReply* New(::google::protobuf::Arena* arena = nullptr) const final {
+    return CreateMaybeMessage<KeyEventReply>(arena);
+  }
+  using ::google::protobuf::Message::CopyFrom;
+  void CopyFrom(const KeyEventReply& from);
+  using ::google::protobuf::Message::MergeFrom;
+  void MergeFrom( const KeyEventReply& from) {
+    KeyEventReply::MergeImpl(*this, from);
+  }
+  private:
+  static void MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg);
+  public:
+  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
+  bool IsInitialized() const final;
+
+  ::size_t ByteSizeLong() const final;
+  const char* _InternalParse(const char* ptr, ::google::protobuf::internal::ParseContext* ctx) final;
+  ::uint8_t* _InternalSerialize(
+      ::uint8_t* target, ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
+  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
+
+  private:
+  ::google::protobuf::internal::CachedSize* AccessCachedSize() const final;
+  void SharedCtor(::google::protobuf::Arena* arena);
+  void SharedDtor();
+  void InternalSwap(KeyEventReply* other);
+
+  private:
+  friend class ::google::protobuf::internal::AnyMetadata;
+  static ::absl::string_view FullMessageName() {
+    return "KeyEventReply";
+  }
+  protected:
+  explicit KeyEventReply(::google::protobuf::Arena* arena);
+  KeyEventReply(::google::protobuf::Arena* arena, const KeyEventReply& from);
+  public:
+
+  static const ClassData _class_data_;
+  const ::google::protobuf::Message::ClassData*GetClassData() const final;
+
+  ::google::protobuf::Metadata GetMetadata() const final;
+
+  // nested types ----------------------------------------------------
+
+  // accessors -------------------------------------------------------
+
+  enum : int {
+    kAcceptedFieldNumber = 1,
+  };
+  // bool accepted = 1;
+  void clear_accepted() ;
+  bool accepted() const;
+  void set_accepted(bool value);
+
+  private:
+  bool _internal_accepted() const;
+  void _internal_set_accepted(bool value);
+
+  public:
+  // @@protoc_insertion_point(class_scope:KeyEventReply)
+ private:
+  class _Internal;
+
+  friend class ::google::protobuf::internal::TcParser;
+  static const ::google::protobuf::internal::TcParseTable<
+      0, 1, 0,
+      0, 2>
+      _table_;
+  friend class ::google::protobuf::MessageLite;
+  friend class ::google::protobuf::Arena;
+  template <typename T>
+  friend class ::google::protobuf::Arena::InternalHelper;
+  using InternalArenaConstructable_ = void;
+  using DestructorSkippable_ = void;
+  struct Impl_ {
+
+        inline explicit constexpr Impl_(
+            ::google::protobuf::internal::ConstantInitialized) noexcept;
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena);
+        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
+                              ::google::protobuf::Arena* arena, const Impl_& from);
+    bool accepted_;
     mutable ::google::protobuf::internal::CachedSize _cached_size_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -1555,6 +1733,33 @@ inline void KeyEvent::_internal_set_key(::uint32_t value) {
   PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
   ;
   _impl_.key_ = value;
+}
+
+// -------------------------------------------------------------------
+
+// KeyEventReply
+
+// bool accepted = 1;
+inline void KeyEventReply::clear_accepted() {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  _impl_.accepted_ = false;
+}
+inline bool KeyEventReply::accepted() const {
+  // @@protoc_insertion_point(field_get:KeyEventReply.accepted)
+  return _internal_accepted();
+}
+inline void KeyEventReply::set_accepted(bool value) {
+  _internal_set_accepted(value);
+  // @@protoc_insertion_point(field_set:KeyEventReply.accepted)
+}
+inline bool KeyEventReply::_internal_accepted() const {
+  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
+  return _impl_.accepted_;
+}
+inline void KeyEventReply::_internal_set_accepted(bool value) {
+  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
+  ;
+  _impl_.accepted_ = value;
 }
 
 #ifdef __GNUC__

--- a/msgs.pb.h
+++ b/msgs.pb.h
@@ -70,9 +70,6 @@ extern UpdateCandidatesDefaultTypeInternal _UpdateCandidates_default_instance_;
 class UpdatePreedit;
 struct UpdatePreeditDefaultTypeInternal;
 extern UpdatePreeditDefaultTypeInternal _UpdatePreedit_default_instance_;
-class UpdateSessionStatus;
-struct UpdateSessionStatusDefaultTypeInternal;
-extern UpdateSessionStatusDefaultTypeInternal _UpdateSessionStatus_default_instance_;
 namespace google {
 namespace protobuf {
 }  // namespace protobuf
@@ -83,181 +80,6 @@ namespace protobuf {
 
 
 // -------------------------------------------------------------------
-
-class UpdateSessionStatus final :
-    public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:UpdateSessionStatus) */ {
- public:
-  inline UpdateSessionStatus() : UpdateSessionStatus(nullptr) {}
-  ~UpdateSessionStatus() override;
-  template<typename = void>
-  explicit PROTOBUF_CONSTEXPR UpdateSessionStatus(::google::protobuf::internal::ConstantInitialized);
-
-  inline UpdateSessionStatus(const UpdateSessionStatus& from)
-      : UpdateSessionStatus(nullptr, from) {}
-  UpdateSessionStatus(UpdateSessionStatus&& from) noexcept
-    : UpdateSessionStatus() {
-    *this = ::std::move(from);
-  }
-
-  inline UpdateSessionStatus& operator=(const UpdateSessionStatus& from) {
-    CopyFrom(from);
-    return *this;
-  }
-  inline UpdateSessionStatus& operator=(UpdateSessionStatus&& from) noexcept {
-    if (this == &from) return *this;
-    if (GetArena() == from.GetArena()
-  #ifdef PROTOBUF_FORCE_COPY_IN_MOVE
-        && GetArena() != nullptr
-  #endif  // !PROTOBUF_FORCE_COPY_IN_MOVE
-    ) {
-      InternalSwap(&from);
-    } else {
-      CopyFrom(from);
-    }
-    return *this;
-  }
-
-  inline const ::google::protobuf::UnknownFieldSet& unknown_fields() const
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.unknown_fields<::google::protobuf::UnknownFieldSet>(::google::protobuf::UnknownFieldSet::default_instance);
-  }
-  inline ::google::protobuf::UnknownFieldSet* mutable_unknown_fields()
-      ABSL_ATTRIBUTE_LIFETIME_BOUND {
-    return _internal_metadata_.mutable_unknown_fields<::google::protobuf::UnknownFieldSet>();
-  }
-
-  static const ::google::protobuf::Descriptor* descriptor() {
-    return GetDescriptor();
-  }
-  static const ::google::protobuf::Descriptor* GetDescriptor() {
-    return default_instance().GetMetadata().descriptor;
-  }
-  static const ::google::protobuf::Reflection* GetReflection() {
-    return default_instance().GetMetadata().reflection;
-  }
-  static const UpdateSessionStatus& default_instance() {
-    return *internal_default_instance();
-  }
-  static inline const UpdateSessionStatus* internal_default_instance() {
-    return reinterpret_cast<const UpdateSessionStatus*>(
-               &_UpdateSessionStatus_default_instance_);
-  }
-  static constexpr int kIndexInFileMessages =
-    3;
-
-  friend void swap(UpdateSessionStatus& a, UpdateSessionStatus& b) {
-    a.Swap(&b);
-  }
-  inline void Swap(UpdateSessionStatus* other) {
-    if (other == this) return;
-  #ifdef PROTOBUF_FORCE_COPY_IN_SWAP
-    if (GetArena() != nullptr &&
-        GetArena() == other->GetArena()) {
-   #else  // PROTOBUF_FORCE_COPY_IN_SWAP
-    if (GetArena() == other->GetArena()) {
-  #endif  // !PROTOBUF_FORCE_COPY_IN_SWAP
-      InternalSwap(other);
-    } else {
-      ::google::protobuf::internal::GenericSwap(this, other);
-    }
-  }
-  void UnsafeArenaSwap(UpdateSessionStatus* other) {
-    if (other == this) return;
-    ABSL_DCHECK(GetArena() == other->GetArena());
-    InternalSwap(other);
-  }
-
-  // implements Message ----------------------------------------------
-
-  UpdateSessionStatus* New(::google::protobuf::Arena* arena = nullptr) const final {
-    return CreateMaybeMessage<UpdateSessionStatus>(arena);
-  }
-  using ::google::protobuf::Message::CopyFrom;
-  void CopyFrom(const UpdateSessionStatus& from);
-  using ::google::protobuf::Message::MergeFrom;
-  void MergeFrom( const UpdateSessionStatus& from) {
-    UpdateSessionStatus::MergeImpl(*this, from);
-  }
-  private:
-  static void MergeImpl(::google::protobuf::Message& to_msg, const ::google::protobuf::Message& from_msg);
-  public:
-  PROTOBUF_ATTRIBUTE_REINITIALIZES void Clear() final;
-  bool IsInitialized() const final;
-
-  ::size_t ByteSizeLong() const final;
-  const char* _InternalParse(const char* ptr, ::google::protobuf::internal::ParseContext* ctx) final;
-  ::uint8_t* _InternalSerialize(
-      ::uint8_t* target, ::google::protobuf::io::EpsCopyOutputStream* stream) const final;
-  int GetCachedSize() const { return _impl_._cached_size_.Get(); }
-
-  private:
-  ::google::protobuf::internal::CachedSize* AccessCachedSize() const final;
-  void SharedCtor(::google::protobuf::Arena* arena);
-  void SharedDtor();
-  void InternalSwap(UpdateSessionStatus* other);
-
-  private:
-  friend class ::google::protobuf::internal::AnyMetadata;
-  static ::absl::string_view FullMessageName() {
-    return "UpdateSessionStatus";
-  }
-  protected:
-  explicit UpdateSessionStatus(::google::protobuf::Arena* arena);
-  UpdateSessionStatus(::google::protobuf::Arena* arena, const UpdateSessionStatus& from);
-  public:
-
-  static const ClassData _class_data_;
-  const ::google::protobuf::Message::ClassData*GetClassData() const final;
-
-  ::google::protobuf::Metadata GetMetadata() const final;
-
-  // nested types ----------------------------------------------------
-
-  // accessors -------------------------------------------------------
-
-  enum : int {
-    kInSessionFieldNumber = 1,
-  };
-  // bool in_session = 1;
-  void clear_in_session() ;
-  bool in_session() const;
-  void set_in_session(bool value);
-
-  private:
-  bool _internal_in_session() const;
-  void _internal_set_in_session(bool value);
-
-  public:
-  // @@protoc_insertion_point(class_scope:UpdateSessionStatus)
- private:
-  class _Internal;
-
-  friend class ::google::protobuf::internal::TcParser;
-  static const ::google::protobuf::internal::TcParseTable<
-      0, 1, 0,
-      0, 2>
-      _table_;
-  friend class ::google::protobuf::MessageLite;
-  friend class ::google::protobuf::Arena;
-  template <typename T>
-  friend class ::google::protobuf::Arena::InternalHelper;
-  using InternalArenaConstructable_ = void;
-  using DestructorSkippable_ = void;
-  struct Impl_ {
-
-        inline explicit constexpr Impl_(
-            ::google::protobuf::internal::ConstantInitialized) noexcept;
-        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                              ::google::protobuf::Arena* arena);
-        inline explicit Impl_(::google::protobuf::internal::InternalVisibility visibility,
-                              ::google::protobuf::Arena* arena, const Impl_& from);
-    bool in_session_;
-    mutable ::google::protobuf::internal::CachedSize _cached_size_;
-    PROTOBUF_TSAN_DECLARE_MEMBER
-  };
-  union { Impl_ _impl_; };
-  friend struct ::TableStruct_msgs_2eproto;
-};// -------------------------------------------------------------------
 
 class UpdatePreedit final :
     public ::google::protobuf::Message /* @@protoc_insertion_point(class_definition:UpdatePreedit) */ {
@@ -499,7 +321,7 @@ class UpdateCandidates final :
                &_UpdateCandidates_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    4;
+    3;
 
   friend void swap(UpdateCandidates& a, UpdateCandidates& b) {
     a.Swap(&b);
@@ -692,7 +514,7 @@ class KeyEvent final :
                &_KeyEvent_default_instance_);
   }
   static constexpr int kIndexInFileMessages =
-    5;
+    4;
 
   friend void swap(KeyEvent& a, KeyEvent& b) {
     a.Swap(&b);
@@ -1044,7 +866,6 @@ class CommandToFcitx final :
     return *internal_default_instance();
   }
   enum CommandCase {
-    kUpdateSessionStatus = 1,
     kCommitText = 2,
     kUpdatePreedit = 3,
     kUpdateCandidates = 4,
@@ -1129,30 +950,10 @@ class CommandToFcitx final :
   // accessors -------------------------------------------------------
 
   enum : int {
-    kUpdateSessionStatusFieldNumber = 1,
     kCommitTextFieldNumber = 2,
     kUpdatePreeditFieldNumber = 3,
     kUpdateCandidatesFieldNumber = 4,
   };
-  // .UpdateSessionStatus update_session_status = 1;
-  bool has_update_session_status() const;
-  private:
-  bool _internal_has_update_session_status() const;
-
-  public:
-  void clear_update_session_status() ;
-  const ::UpdateSessionStatus& update_session_status() const;
-  PROTOBUF_NODISCARD ::UpdateSessionStatus* release_update_session_status();
-  ::UpdateSessionStatus* mutable_update_session_status();
-  void set_allocated_update_session_status(::UpdateSessionStatus* value);
-  void unsafe_arena_set_allocated_update_session_status(::UpdateSessionStatus* value);
-  ::UpdateSessionStatus* unsafe_arena_release_update_session_status();
-
-  private:
-  const ::UpdateSessionStatus& _internal_update_session_status() const;
-  ::UpdateSessionStatus* _internal_mutable_update_session_status();
-
-  public:
   // .CommitText commit_text = 2;
   bool has_commit_text() const;
   private:
@@ -1215,7 +1016,6 @@ class CommandToFcitx final :
   // @@protoc_insertion_point(class_scope:CommandToFcitx)
  private:
   class _Internal;
-  void set_has_update_session_status();
   void set_has_commit_text();
   void set_has_update_preedit();
   void set_has_update_candidates();
@@ -1225,7 +1025,7 @@ class CommandToFcitx final :
 
   friend class ::google::protobuf::internal::TcParser;
   static const ::google::protobuf::internal::TcParseTable<
-      0, 4, 4,
+      0, 3, 3,
       0, 2>
       _table_;
   friend class ::google::protobuf::MessageLite;
@@ -1245,7 +1045,6 @@ class CommandToFcitx final :
     union CommandUnion {
       constexpr CommandUnion() : _constinit_{} {}
         ::google::protobuf::internal::ConstantInitialized _constinit_;
-      ::UpdateSessionStatus* update_session_status_;
       ::CommitText* commit_text_;
       ::UpdatePreedit* update_preedit_;
       ::UpdateCandidates* update_candidates_;
@@ -1274,82 +1073,6 @@ class CommandToFcitx final :
 // -------------------------------------------------------------------
 
 // CommandToFcitx
-
-// .UpdateSessionStatus update_session_status = 1;
-inline bool CommandToFcitx::has_update_session_status() const {
-  return command_case() == kUpdateSessionStatus;
-}
-inline bool CommandToFcitx::_internal_has_update_session_status() const {
-  return command_case() == kUpdateSessionStatus;
-}
-inline void CommandToFcitx::set_has_update_session_status() {
-  _impl_._oneof_case_[0] = kUpdateSessionStatus;
-}
-inline void CommandToFcitx::clear_update_session_status() {
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  if (command_case() == kUpdateSessionStatus) {
-    if (GetArena() == nullptr) {
-      delete _impl_.command_.update_session_status_;
-    }
-    clear_has_command();
-  }
-}
-inline ::UpdateSessionStatus* CommandToFcitx::release_update_session_status() {
-  // @@protoc_insertion_point(field_release:CommandToFcitx.update_session_status)
-  if (command_case() == kUpdateSessionStatus) {
-    clear_has_command();
-    auto* temp = _impl_.command_.update_session_status_;
-    if (GetArena() != nullptr) {
-      temp = ::google::protobuf::internal::DuplicateIfNonNull(temp);
-    }
-    _impl_.command_.update_session_status_ = nullptr;
-    return temp;
-  } else {
-    return nullptr;
-  }
-}
-inline const ::UpdateSessionStatus& CommandToFcitx::_internal_update_session_status() const {
-  return command_case() == kUpdateSessionStatus ? *_impl_.command_.update_session_status_ : reinterpret_cast<::UpdateSessionStatus&>(::_UpdateSessionStatus_default_instance_);
-}
-inline const ::UpdateSessionStatus& CommandToFcitx::update_session_status() const ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  // @@protoc_insertion_point(field_get:CommandToFcitx.update_session_status)
-  return _internal_update_session_status();
-}
-inline ::UpdateSessionStatus* CommandToFcitx::unsafe_arena_release_update_session_status() {
-  // @@protoc_insertion_point(field_unsafe_arena_release:CommandToFcitx.update_session_status)
-  if (command_case() == kUpdateSessionStatus) {
-    clear_has_command();
-    auto* temp = _impl_.command_.update_session_status_;
-    _impl_.command_.update_session_status_ = nullptr;
-    return temp;
-  } else {
-    return nullptr;
-  }
-}
-inline void CommandToFcitx::unsafe_arena_set_allocated_update_session_status(::UpdateSessionStatus* value) {
-  // We rely on the oneof clear method to free the earlier contents
-  // of this oneof. We can directly use the pointer we're given to
-  // set the new value.
-  clear_command();
-  if (value) {
-    set_has_update_session_status();
-    _impl_.command_.update_session_status_ = value;
-  }
-  // @@protoc_insertion_point(field_unsafe_arena_set_allocated:CommandToFcitx.update_session_status)
-}
-inline ::UpdateSessionStatus* CommandToFcitx::_internal_mutable_update_session_status() {
-  if (command_case() != kUpdateSessionStatus) {
-    clear_command();
-    set_has_update_session_status();
-    _impl_.command_.update_session_status_ = CreateMaybeMessage<::UpdateSessionStatus>(GetArena());
-  }
-  return _impl_.command_.update_session_status_;
-}
-inline ::UpdateSessionStatus* CommandToFcitx::mutable_update_session_status() ABSL_ATTRIBUTE_LIFETIME_BOUND {
-  ::UpdateSessionStatus* _msg = _internal_mutable_update_session_status();
-  // @@protoc_insertion_point(field_mutable:CommandToFcitx.update_session_status)
-  return _msg;
-}
 
 // .CommitText commit_text = 2;
 inline bool CommandToFcitx::has_commit_text() const {
@@ -1700,33 +1423,6 @@ inline void UpdatePreedit::set_allocated_text(std::string* value) {
         }
   #endif  // PROTOBUF_FORCE_COPY_DEFAULT_STRING
   // @@protoc_insertion_point(field_set_allocated:UpdatePreedit.text)
-}
-
-// -------------------------------------------------------------------
-
-// UpdateSessionStatus
-
-// bool in_session = 1;
-inline void UpdateSessionStatus::clear_in_session() {
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  _impl_.in_session_ = false;
-}
-inline bool UpdateSessionStatus::in_session() const {
-  // @@protoc_insertion_point(field_get:UpdateSessionStatus.in_session)
-  return _internal_in_session();
-}
-inline void UpdateSessionStatus::set_in_session(bool value) {
-  _internal_set_in_session(value);
-  // @@protoc_insertion_point(field_set:UpdateSessionStatus.in_session)
-}
-inline bool UpdateSessionStatus::_internal_in_session() const {
-  PROTOBUF_TSAN_READ(&_impl_._tsan_detect_race);
-  return _impl_.in_session_;
-}
-inline void UpdateSessionStatus::_internal_set_in_session(bool value) {
-  PROTOBUF_TSAN_WRITE(&_impl_._tsan_detect_race);
-  ;
-  _impl_.in_session_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/msgs.proto
+++ b/msgs.proto
@@ -2,7 +2,6 @@ syntax = "proto3";
 
 message CommandToFcitx {
   oneof command {
-    UpdateSessionStatus update_session_status = 1;
     CommitText commit_text = 2;
     UpdatePreedit update_preedit = 3;
     UpdateCandidates update_candidates = 4;
@@ -12,8 +11,6 @@ message CommandToFcitx {
 message CommitText { string text = 1; }
 
 message UpdatePreedit { string text = 1; }
-
-message UpdateSessionStatus { bool in_session = 1; }
 
 message UpdateCandidates { repeated string candidates = 1; }
 

--- a/msgs.proto
+++ b/msgs.proto
@@ -15,3 +15,5 @@ message UpdatePreedit { string text = 1; }
 message UpdateCandidates { repeated string candidates = 1; }
 
 message KeyEvent { uint32 key = 1; }
+
+message KeyEventReply { bool accepted = 1; }


### PR DESCRIPTION
Currently, we use a ZMQ publisher socket to send the events and the input method will pick up the event and do some processing and call the bridge. This is all fine but Fcitx5 has `KeyEvent::filterAndAccept`. By calling it, you acknowledge that this event is handled and it won't propagate further. From the user's perspective, once a key event is acknowledged, if that key is something can be shown on screen, it won't unless your input method engine commits that key. But if the key event is an action, say the "ENTER/RETURN" key, your input method has no way of committing that key.

This means, our current way of blindly acknowledging every key will cause those action key event to be lost. To mediate this, we do the filtering in the bridge. This works if we know what the input method needs. So we have assumption on the behavior of the input method. But we want to be more generic than that. So, it's better for the input method to handle the key event entirely (we only filter the key release and modifiers, so far, I don't see the need to pass it to the input method, but we can pass everything to the input method if there such need).

But to do so, we basically have to give up the publisher socket. Because when you publish a message using ZMQ, it's fire-and-forget. But in this case, we want the return value (e.g., a bool to tell whether you want to accept the key event). So, in this PR, we change the publisher socket to a regular request-reply socket. This doesn't mean the input method on the other side of ZMQ needs to be synchronous. The acknowledging part is, but there's no thing stops you from making the acknowledgement synchronously but later do other things asynchronously.